### PR TITLE
Add index on source column

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -50,6 +50,12 @@
 					<sorting>ascending</sorting>
 				</field>
 			</index>
+			<index>
+				<name>ss_source</name>
+				<field>
+					<name>source</name>
+				</field>
+			</index>
 		</declaration>
 	</table>
 </database>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <description>Collects information from other Nextcloud servers about enabled apps, settings, etc and visualize them</description>
     <licence>AGPL</licence>
     <author>Bjoern Schiessle</author>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
     <namespace>Survey_Server</namespace>
     <category>other</category>
     <dependencies>


### PR DESCRIPTION
Fix https://github.com/nextcloud/survey_client/issues/29

The problem was the delete took more then the 5 seconds default timeout....
https://github.com/nextcloud/survey_server/blob/5be7226ff59e2cda735201c2abcc6bc807b24e2a/lib/Service/StatisticService.php#L89

Deployed on the installation and it works again.